### PR TITLE
Allow builded lib to be in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 /docs/
 /examples/
 /test/
+!lib


### PR DESCRIPTION
This enables npm publish to pack builded lib into package so it does not need to be build on install